### PR TITLE
Drop usage of ES6+ APIs in Model

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Model.js
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Model.js
@@ -118,19 +118,23 @@ function Model(initialState, stateInitializer)
 
 		function registerProps(obj) {
 
-			var descs = Object.getOwnPropertyDescriptors(obj);
-			for (var p in descs) {
+			var keys = Object.getOwnPropertyNames(obj);
+			for (var i in keys) {
+				var p = keys[i];
 				if (p === "constructor") { continue; }
 				var value = state[p];
 				if (value instanceof Function) {
 					node[p] = wrapFunction(value);
 					state[p] = node[p];
 				}
-				else if (descs[p].get instanceof Function)
-				{
-					if (isThenable(value)) { node[p] = null; dealWithPromise(p, value); }
-					else { node[p] = wrap(p, value); }
-					propGetters[p] = descs[p].get;
+				else {
+					var descriptor = Object.getOwnPropertyDescriptor(obj, p);
+					if(descriptor.get instanceof Function)
+					{
+						if (isThenable(value)) { node[p] = null; dealWithPromise(p, value); }
+						else { node[p] = wrap(p, value); }
+						propGetters[p] = descriptor.get;
+					}
 				}
 			}
 

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/ViewModelAdapter.js
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/ViewModelAdapter.js
@@ -38,12 +38,11 @@ exports.adaptView = function(view, viewModule, model) {
 		}
 	}
 
-	var viewProps = Object.getOwnPropertyDescriptors(view);
-	for (var key in viewProps) {
-		if(key in model
-			&& !viewProps[key].enumerable
-			&& view[key] instanceof Observable)
-		{
+	var keys = Object.getOwnPropertyNames(view);
+	for (var key in keys) {
+		if(!(key in model)) continue;
+		var descriptor = Object.getOwnPropertyDescriptor(view, key);
+		if(!descriptor.enumerable && view[key] instanceof Observable) {
 			wrapProperty(key);
 		}
 	}


### PR DESCRIPTION
`Object.getOwnPropertyDescriptors` is an ES6+ feature, and is not implemented on iOS <= 9.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
