### PR TITLE
Model: Remove support for model expressions

### DIFF
--- a/Source/Fuse.Models/JavaScript.Model.uno
+++ b/Source/Fuse.Models/JavaScript.Model.uno
@@ -14,23 +14,24 @@ namespace Fuse.Models
 	{
 		class ModelData
 		{
-			public IExpression Model;
+			public string ModulePath;
 			public NameTable NameTable;
 		}
+		static PropertyHandle _modelHandle = Properties.CreateHandle();
 		
 		//Requires a NameTable that will be set first.
-		[UXAttachedPropertySetter("JavaScript.Model"), UXNameScope, UXAuxNameTable("ModelNameTable")]
-		public static void SetModel(Visual v, IExpression model)
+		[UXAttachedPropertySetter("JavaScript.Model"), UXAuxNameTable("ModelNameTable")]
+		public static void SetModel(Visual v, string modulePath)
 		{
 			var md = v.Properties.Get( _modelHandle ) as ModelData;
 			if (md == null)
 			{
-				md = new ModelData{ Model = model };
+				md = new ModelData { ModulePath = modulePath };
 				v.Properties.Set( _modelHandle, md );
 			}
 			else
 			{
-				md.Model = model;
+				md.ModulePath = modulePath;
 			}
 			
 			Complete( md, v );
@@ -41,16 +42,13 @@ namespace Fuse.Models
 			v.RemoveAllChildren<ModelJavaScript>();
 			
 			//avoid creating without the NameTable as unfortunately UX will set the Model prior to the NameTable
-			if (md.NameTable == null || md.Model == null)
+			if (md.NameTable == null || md.ModulePath == null)
 				return;
-				
-			var parsed = ModelJavaScript.ParseModelExpression(md.Model, md.NameTable);
-			v.Children.Add( new ModelJavaScript(parsed, md.NameTable, null) );
+			
+			v.Children.Add( new ModelJavaScript(md.NameTable, md.ModulePath, null) );
 		}
-
-		static PropertyHandle _modelHandle = Properties.CreateHandle();
 		
-		[UXAttachedPropertySetterAttribute("ModelNameTable")]
+		[UXAttachedPropertySetter("ModelNameTable")]
 		public static void SetModelNameTable(Visual v, NameTable nt)
 		{
 			var md = v.Properties.Get( _modelHandle ) as ModelData;
@@ -68,127 +66,33 @@ namespace Fuse.Models
 		}
 
 		//TODO: This should probably be JavaScript.Model, Preview would need to be adjusted as well
-		[UXAttachedPropertySetter("Model"), UXNameScope]
-		public static void SetAppModel(IRootVisualProvider rootVisualProvider, IExpression model)
+		[UXAttachedPropertySetter("Model")]
+		public static void SetAppModel(IRootVisualProvider rootVisualProvider, string modulePath)
 		{
 			rootVisualProvider.Root.RemoveAllChildren<ModelJavaScript>();
 
-			var _appModel = ModelJavaScript.CreateFromPreviewState(rootVisualProvider.Root, model);
-			rootVisualProvider.Root.Children.Add(_appModel);
-		}
-
-		internal class ParsedModelExpression
-		{
-			public IExpression Source;
-			public string ModuleName;
-			public string ClassName;
-			public List<string> Args = new List<string>();
-			public List<JavaScript.Dependency> Dependencies = new List<JavaScript.Dependency>();
-			
-			public string ArgString
-			{
-				get
-				{
-					var builder = new StringBuilder();
-					for (int i = 0; i < Args.Count; ++i)
-					{
-						builder.Append(", ");
-						builder.Append(Args[i]);
-					}
-					return builder.ToString();
-				}
-			}
-			
-			public bool CompatibleTo( ParsedModelExpression o )
-			{
-				//there is no way to migrate these now as they might refer to tree objects, thus reject entirely
-				if (Args.Count != 0 || o.Args.Count != 0 ||	
-					Dependencies.Count != 0 || o.Dependencies.Count != 0)
-					return false;
-					
-				return o.ModuleName == ModuleName &&
-					o.ClassName == ClassName;
-			}
-		}
-		
-		internal static ParsedModelExpression ParseModelExpression(IExpression exp, NameTable nt)
-		{
-			var data = exp as Data;
-			if (data != null)
-			{
-				var className = data.Key;
-				return new ParsedModelExpression
-				{
-					ClassName = className,
-					ModuleName = className,
-					Source = exp,
-				};
-			}
-
-			var divide = exp as Divide;
-			if (divide != null)
-			{
-				var left = ParseModelExpression(divide.Left, nt);
-				var right = ParseModelExpression(divide.Right, nt);
-				
-				if (left.Args.Count > 0 || left.Dependencies.Count > 0)
-					throw new Exception( "Invalid Model path expression: " + exp);
-				
-				right.ModuleName = left.ModuleName + "/" + right.ModuleName;
-				right.Source = exp;
-				return right;
-			}
-
-			var nfc = exp as Fuse.Reactive.NamedFunctionCall;
-			if (nfc != null)
-			{
-				var result = new ParsedModelExpression
-				{
-					ClassName = nfc.Name,
-					ModuleName = nfc.Name,
-					Source = exp,
-				};
-
-				for (int i = 0; i < nfc.Arguments.Count; i++)
-				{
-					var argName = "__dep" + i;
-					result.Dependencies.Add(new JavaScript.Dependency(argName, nfc.Arguments[i]));
-					result.Args.Add( argName );
-				}
-
-				return result;
-			}
-			
-			throw new Exception("Invalid Model path expression: " + exp);
+			var appModel = ModelJavaScript.CreateFromPreviewState(rootVisualProvider.Root, modulePath);
+			rootVisualProvider.Root.Children.Add(appModel);
 		}
 
 		void SetupModel()
 		{
-			if (_model == null)
+			if (_modulePath == null)
 			{
 				Code = string.Empty;
 				return;
 			}
-
-			//TODO: this should not be necessary. It's done because there's a UX processor error, we get
-			//the IExpression prior to it being complete
-			var module = ParseModelExpression( _model.Source, _nameTable );
-
-			Dependencies.Clear();
-			for (int i=0; i < module.Dependencies.Count; ++i)
-				Dependencies.Add( module.Dependencies[i] );
 			
-			var code = "var Model = require('FuseJS/Internal/Model');\n"+
-					"var ViewModelAdapter = require('FuseJS/Internal/ViewModelAdapter')\n";
-					
-			code += "var self = this;\n"+
-					"var modelClass = require('" + module.ModuleName + "');\n"+
+			var code = 
+					"var Model = require('FuseJS/Internal/Model');\n"+
+					"var ViewModelAdapter = require('FuseJS/Internal/ViewModelAdapter')\n"+
+					"var self = this;\n"+
+					"var modelClass = require('" + _modulePath + "');\n"+
 					"if (!(modelClass instanceof Function) && 'default' in modelClass) { modelClass = modelClass.default }\n"+
-					"if (!(modelClass instanceof Function) && '" + module.ClassName +"' in modelClass) { modelClass = modelClass."+ module.ClassName +" }\n"+
-					"if (!(modelClass instanceof Function)) { throw new Error('\"" + module.ModuleName + "\" does not export a class or function required to construct a Model'); }\n"+
+					"if (!(modelClass instanceof Function)) { throw new Error('\"" + _modulePath + "\" does not export a class or function required to construct a Model'); }\n"+
 					"var modelInstance = Object.create(modelClass.prototype);\n"+
 					"module.exports = new Model(modelInstance, function() {\n"+
-					"    modelClass.call(modelInstance" + module.ArgString + ");\n"+
+					"    modelClass.call(modelInstance);\n"+
 					"    ViewModelAdapter.adaptView(self, module, modelInstance);\n"+
 					"    return modelInstance;\n"+
 					"});\n";
@@ -196,11 +100,10 @@ namespace Fuse.Models
 		}
 		
 		string _previewStateModelId; //if null then not migrated
-		
-		static public ModelJavaScript CreateFromPreviewState(Visual where, IExpression model)
+
+		static public ModelJavaScript CreateFromPreviewState(Visual where, string modulePath)
 		{
 			string previewStateId = "ModelJavaScript-App";
-			var parsed = ParseModelExpression(model, null);
 			
 			var previewState = PreviewState.Find(where);
 			if (previewState != null && previewState.Current != null)
@@ -208,7 +111,7 @@ namespace Fuse.Models
 				var previous = previewState.Current.Consume( previewStateId ) as ModelJavaScript;
 				if (previous != null)
 				{
-					if (previous._model.CompatibleTo(parsed))
+					if (previous._modulePath == modulePath)
 						return previous;
 					else
 						previous.Dispose();
@@ -216,26 +119,22 @@ namespace Fuse.Models
 			}
 			
 			//app-level model does not have a nametable otherwise migration would not be possible
-			var js = new ModelJavaScript(parsed, null, previewStateId );
+			var js = new ModelJavaScript(null, modulePath, previewStateId);
 			return js;
 		}
 		
-		ParsedModelExpression _model;
-		internal ModelJavaScript(ParsedModelExpression model, NameTable nt,
-			string previewStateId)
+		string _modulePath;
+		internal ModelJavaScript(NameTable nt, string modulePath, string previewStateId)
 			: base(nt)
 		{
 			_previewStateModelId = previewStateId;
-			_model = model;
+			_modulePath = modulePath;
 			FileName = "(model-script)";
+			SetupModel();
 		}
 		
 		protected override void OnRooted()
 		{
-			//TODO: prior to base.OnRooted is questionable... The TODO: in SetupModel though is part of the
-			//reason we can't easily fix this now. Ideally the constructor would just set the needed values
-			SetupModel();
-			
 			base.OnRooted();
 			
 			if (_previewStateModelId != null)

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -251,7 +251,7 @@ namespace Fuse.Models.Test
 		}
 
 		[Test]
-		public void MultiBasic()
+		public void Multi()
 		{
 			var e = new UX.Model.Multi();
 			using (var root = TestRootPanel.CreateWithChild(e))

--- a/Source/Fuse.Models/Tests/UX/Async.js
+++ b/Source/Fuse.Models/Tests/UX/Async.js
@@ -1,5 +1,5 @@
 
-export class Async {
+export default class Async {
 	constructor() {
 		this.foo = 10;
 	}

--- a/Source/Fuse.Models/Tests/UX/Basic.js
+++ b/Source/Fuse.Models/Tests/UX/Basic.js
@@ -1,4 +1,4 @@
-export class Basic {
+export default class Basic {
 	constructor() {
 		this.isSet = false
 	}

--- a/Source/Fuse.Models/Tests/UX/Bind.js
+++ b/Source/Fuse.Models/Tests/UX/Bind.js
@@ -1,6 +1,6 @@
 var instCount = 0
 
-export class Bind {
+export default class Bind {
 	constructor(view) {
 		this.id = instCount++
 		this.Load = 5

--- a/Source/Fuse.Models/Tests/UX/Disconnected.js
+++ b/Source/Fuse.Models/Tests/UX/Disconnected.js
@@ -11,7 +11,7 @@ class Inner {
 var cur = new Inner(5)
 var next = new Inner(10)
 
-export class Disconnected {
+export default class Disconnected {
 	constructor() {
 		this.inner = cur
 	}

--- a/Source/Fuse.Models/Tests/UX/Disconnected.ux
+++ b/Source/Fuse.Models/Tests/UX/Disconnected.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Disconnected" Model="UX/Disconnected()">
+<Panel ux:Class="UX.Model.Disconnected" Model="UX/Disconnected">
 	<FuseTest.DudElement Value="{inner.value}" ux:Name="a"/>
 	
 	<FuseTest.Invoke Handler="{updateNext}" ux:Name="callUpdateNext"/>

--- a/Source/Fuse.Models/Tests/UX/Each.js
+++ b/Source/Fuse.Models/Tests/UX/Each.js
@@ -4,7 +4,7 @@ class Item {
 	}
 }
 
-export class Each {
+export default class Each {
 	constructor() {
 		this.simple = [ "one", "two", "three" ]
 		this.items = [ "one", "two", "three" ].map( n => new Item(n) )

--- a/Source/Fuse.Models/Tests/UX/EmptyList.js
+++ b/Source/Fuse.Models/Tests/UX/EmptyList.js
@@ -1,4 +1,4 @@
-export class EmptyList {
+export default class EmptyList {
 	constructor() {
 		this.items = [ 1, 2, 3 ];
 		this.promisedItems = new Promise(resolve => setTimeout(() => resolve([3, 4, 5]), 0));

--- a/Source/Fuse.Models/Tests/UX/Function.js
+++ b/Source/Fuse.Models/Tests/UX/Function.js
@@ -1,4 +1,4 @@
-export class Function {
+export default class Function {
 	constructor() {
 		this.count = 3
 	}

--- a/Source/Fuse.Models/Tests/UX/Function.ux
+++ b/Source/Fuse.Models/Tests/UX/Function.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Function" Model="UX/Function()">
+<Panel ux:Class="UX.Model.Function" Model="UX/Function">
 	<FuseTest.DudElement StringValue="{stars}" ux:Name="s"/>
 	
 	<FuseTest.Invoke Handler="{incr}" ux:Name="callIncr"/>

--- a/Source/Fuse.Models/Tests/UX/List.js
+++ b/Source/Fuse.Models/Tests/UX/List.js
@@ -1,4 +1,4 @@
-export class List {
+export default class List {
 	constructor() { 
 		this.items = []
 		

--- a/Source/Fuse.Models/Tests/UX/List.ux
+++ b/Source/Fuse.Models/Tests/UX/List.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.List" Model="UX/List()">
+<Panel ux:Class="UX.Model.List" Model="UX/List">
 	<FuseTest.ObservableCollector ux:Name="oc" Items="{items}"/>
 	
 	<FuseTest.Invoke Handler="{add}" ux:Name="callAdd"/>

--- a/Source/Fuse.Models/Tests/UX/ListOrder.js
+++ b/Source/Fuse.Models/Tests/UX/ListOrder.js
@@ -1,4 +1,4 @@
-export class ListOrder {
+export default class ListOrder {
 	constructor() { 
 		this.items = [ 2, 3 ]
 		

--- a/Source/Fuse.Models/Tests/UX/ListOrder.ux
+++ b/Source/Fuse.Models/Tests/UX/ListOrder.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.ListOrder" Model="UX/ListOrder()">
+<Panel ux:Class="UX.Model.ListOrder" Model="UX/ListOrder">
 	<FuseTest.ObservableCollector ux:Name="oc" Items="{items}"/>
 	
 	<FuseTest.Invoke Handler="{add}" ux:Name="callAdd"/>

--- a/Source/Fuse.Models/Tests/UX/Loop.js
+++ b/Source/Fuse.Models/Tests/UX/Loop.js
@@ -1,4 +1,4 @@
-export class Loop {
+export default class Loop {
 	constructor() {
 		this.next = this
 		this.value = "%"

--- a/Source/Fuse.Models/Tests/UX/Loop.ux
+++ b/Source/Fuse.Models/Tests/UX/Loop.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Loop" Model="UX/Loop()">
+<Panel ux:Class="UX.Model.Loop" Model="UX/Loop">
 	<FuseTest.DudElement StringValue="{value}" ux:Name="a"/>
 	<FuseTest.DudElement StringValue="{next.value}" ux:Name="b"/>
 	<FuseTest.DudElement StringValue="{next.next.value}" ux:Name="c"/>

--- a/Source/Fuse.Models/Tests/UX/Loop2.ux
+++ b/Source/Fuse.Models/Tests/UX/Loop2.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Loop2" Model="UX/Loop2()">
+<Panel ux:Class="UX.Model.Loop2" Model="UX/Loop2">
 	<Navigator DefaultPath="Home" Pages="{pages}">
 		<PageControl Interaction="None" ux:Name="Home" Pages="{homePages}" ActiveIndex="{pageIndex}">
 			<Page ux:Template="Flights">

--- a/Source/Fuse.Models/Tests/UX/Multi.js
+++ b/Source/Fuse.Models/Tests/UX/Multi.js
@@ -1,5 +1,9 @@
-export class Multi {
-	constructor(v) {
-		this.value = v
+export default class Multi {
+	constructor() {
+		this.Value = undefined;
+	}
+
+	get value() {
+		return this.Value;
 	}
 }

--- a/Source/Fuse.Models/Tests/UX/Multi.ux
+++ b/Source/Fuse.Models/Tests/UX/Multi.ux
@@ -1,11 +1,18 @@
-<Panel ux:Class="UX.Model.Multi" Model="UX/Multi(1)">
-	<FuseTest.DudElement Value="{value}" ux:Name="a"/>
+<Panel ux:Class="UX.Model.Multi">
+
+	<Panel ux:Class="_Inner" Model="UX/Multi">
+		<float ux:Property="Value" />
+	</Panel>
+
+	<_Inner Value="1">
+		<FuseTest.DudElement Value="{value}" ux:Name="a"/>
+	</_Inner>
 	
-	<Panel Model="UX/Multi(2)">
+	<_Inner Value="2">
 		<FuseTest.DudElement Value="{value}" ux:Name="b"/>
-	</Panel>
+	</_Inner>
 	
-	<Panel Model="UX/Multi(3)">
+	<_Inner Value="3">
 		<FuseTest.DudElement Value="{value}" ux:Name="c"/>
-	</Panel>
+	</_Inner>
 </Panel>

--- a/Source/Fuse.Models/Tests/UX/MultiCounter.js
+++ b/Source/Fuse.Models/Tests/UX/MultiCounter.js
@@ -1,6 +1,6 @@
 import Counter from "./MultiCounter_Counter"
 
-export class MultiCounter {
+export default class MultiCounter {
 	constructor() {
 		this.counters = [ new Counter() ];
 	}

--- a/Source/Fuse.Models/Tests/UX/Nested.js
+++ b/Source/Fuse.Models/Tests/UX/Nested.js
@@ -8,7 +8,7 @@ class Inner {
 	}
 }
 
-export class Nested {
+export default class Nested {
 	constructor() { 
 		this.a = new Inner(1)
 		this.b = new Inner(2)

--- a/Source/Fuse.Models/Tests/UX/Nested.ux
+++ b/Source/Fuse.Models/Tests/UX/Nested.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Nested" Model="UX/Nested()">
+<Panel ux:Class="UX.Model.Nested" Model="UX/Nested">
 	<FuseTest.DudElement Value="{a.value}"/>
 	<FuseTest.DudElement Value="{b.value}"/>
 	<FuseTest.DudElement Value="{c.value}"/>

--- a/Source/Fuse.Models/Tests/UX/NestedAccessor.js
+++ b/Source/Fuse.Models/Tests/UX/NestedAccessor.js
@@ -12,7 +12,7 @@ class Inner {
 	}
 }
 
-export class NestedAccessor {
+export default class NestedAccessor {
 	constructor() {
 		this.inner = new Inner()
 	}

--- a/Source/Fuse.Models/Tests/UX/Pod.js
+++ b/Source/Fuse.Models/Tests/UX/Pod.js
@@ -1,4 +1,4 @@
-export class Pod {
+export default class Pod {
 	constructor() {
 		this.data = {
 			value: "a",

--- a/Source/Fuse.Models/Tests/UX/Pod.ux
+++ b/Source/Fuse.Models/Tests/UX/Pod.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.Model.Pod" Model="UX/Pod()">
+<Panel ux:Class="UX.Model.Pod" Model="UX/Pod">
 	<FuseTest.DudElement StringValue="{data.value}" ux:Name="a"/>
 	<FuseTest.DudElement StringValue="{data.nest.value}" ux:Name="b"/>
 	

--- a/Source/Fuse.Models/Tests/UX/ReplaceAt.js
+++ b/Source/Fuse.Models/Tests/UX/ReplaceAt.js
@@ -23,7 +23,7 @@ class TodoList {
 	}
 }
 
-export class ReplaceAt {
+export default class ReplaceAt {
 	constructor() {
 		this.todoList = new TodoList()
 		this.feedTheCat = feedTheCat = this.todoList.todos[1]

--- a/Source/Fuse.Models/Tests/UX/UseCase1.js
+++ b/Source/Fuse.Models/Tests/UX/UseCase1.js
@@ -4,7 +4,7 @@ class Item {
 	}
 }
 
-export class UseCase1 {
+export default class UseCase1 {
 	constructor() {
 		this.items = [ "one", "two", "three", "four", "five" ].map( n => new Item(n) )
 		this.sel = [ this.items[4] ]


### PR DESCRIPTION
Depends on getting this through the pipeline (merged to master + stuff): https://github.com/fusetools/uno/pull/1466


- The `Model=""` attribute now only accepts a module path
    - Meaning that the `Model="Foo()"` syntax is now deprecated
- ux:Property is now the only way to inject values from UX
- Root model classes _must_ be exported using `export default`

Tests have been updated to cope with the new reality
